### PR TITLE
Fix for ping command not found on web container

### DIFF
--- a/containers/nginx/Dockerfile
+++ b/containers/nginx/Dockerfile
@@ -5,7 +5,7 @@ ENV PHP_HOST phpfpm
 ENV PHP_PORT 9000
 ENV APP_MAGE_MODE default
 
-RUN apt-get update && apt-get install -y dos2unix openssl
+RUN apt-get update && apt-get install -y dos2unix openssl iputils-ping
 
 COPY ./conf/nginx.conf /etc/nginx/
 COPY ./conf/default.conf /etc/nginx/conf.d/


### PR DESCRIPTION
Add iputils-ping to apt-get command on web dockerfile